### PR TITLE
fixes for purescript 0.9.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-eff": "^2.0.0",
-    "purescript-maybe": "^2.0.0"
+    "purescript-eff": "^3.1.0",
+    "purescript-maybe": "^3.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   ],
   "dependencies": {
     "purescript-eff": "latest",
-    "purescript-maybe": "~0.3.5"
+    "purescript-maybe": "~1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-eff": "latest",
-    "purescript-maybe": "~1.0.0"
+    "purescript-eff": "^2.0.0",
+    "purescript-maybe": "^2.0.0"
   }
 }

--- a/src/Web/Cookies.purs
+++ b/src/Web/Cookies.purs
@@ -6,8 +6,9 @@ module Web.Cookies (
          ) where
 
 import Prelude
-import Control.Monad.Eff
-import Data.Maybe
+import Control.Monad.Eff (Eff)
+import Data.Array (uncons)
+import Data.Maybe (Maybe(Just, Nothing))
 
 foreign import data COOKIE :: !
 
@@ -21,8 +22,9 @@ getCookie :: forall eff value. String -> Eff (cookie :: COOKIE | eff) (Maybe val
 getCookie key = do
     cook <- _getCookie key
     prepare cook
-    where prepare [] = return Nothing
-          prepare [value] = return $ Just value
+    where prepare arr = case uncons arr of
+            Just { head: value } -> pure $ Just value
+            Nothing -> pure Nothing
 
 -- |  Delete cookie with specified name
 foreign import deleteCookie :: forall eff. String -> Eff (cookie :: COOKIE | eff) Unit

--- a/src/Web/Cookies.purs
+++ b/src/Web/Cookies.purs
@@ -6,11 +6,11 @@ module Web.Cookies (
          ) where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Eff (Eff, kind Effect)
 import Data.Array (uncons)
 import Data.Maybe (Maybe(Just, Nothing))
 
-foreign import data COOKIE :: !
+foreign import data COOKIE :: Effect
 
 -- | Set cookie with specified name and value. Last argument (opts) is a map of optional arguments such as expiration time
 foreign import setCookie :: forall eff value opts. String -> value -> opts -> Eff (cookie :: COOKIE | eff) Unit


### PR DESCRIPTION
I just fixed compiler errors and warnings.

Note the change in getCookie. "Incomplete case" is now compiler error so I had to change pattern [value] to (value:_), _getCookie cannot return an array with more than one element anyway (as far as I can see). You should probably use Nullable instead of Array but that's another story.
